### PR TITLE
Simplify package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1.3)
-project(hebi_cpp_api_ros_examples)
+project(hebi_cpp_api_examples)
 
 set(CMAKE_CXX_STANDARD_REQUIRED 11)
 

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>hebi_cpp_api_ros_examples</name>
+  <name>hebi_cpp_api_examples</name>
   <version>1.0.0</version>
   <description>Examples of using HEBI components through ROS, using the HEBI C++ API.</description>
   <maintainer email="matt@hebirobotics.com">Matthew Tesch</maintainer>


### PR DESCRIPTION
(ROS is in repo name to disambiguate internally, but is superfluous in the actual package name)